### PR TITLE
feat:cv ingestion infrastructure

### DIFF
--- a/CVBot.Domain/CvAssistant.cs
+++ b/CVBot.Domain/CvAssistant.cs
@@ -28,7 +28,7 @@ public class CvAssistant(ICvContextRetriever contextRetriever, IReasoningModel r
 
 
         var contextualSystemPrompt = BasePrompt + Environment.NewLine + ConvertContextToPromptPatch(chunks);
-        var response = await reasoningModel.Answer(query, contextualSystemPrompt);
+        var response = await reasoningModel.AnswerAsync(query, contextualSystemPrompt);
 
         return response.IsFailure
             ? Result.Failure<CvAssistantAnswer>(FailureToReplyMessage)

--- a/CVBot.Domain/Intelligence/IReasoningModel.cs
+++ b/CVBot.Domain/Intelligence/IReasoningModel.cs
@@ -4,5 +4,5 @@ namespace CVBot.Domain.Intelligence;
 
 public interface IReasoningModel
 {
-    public Task<Result<string>> Answer(string prompt, string systemPrompt);
+    public Task<Result<string>> AnswerAsync(string prompt, string systemPrompt);
 }

--- a/CVBot.Infrastructure/AiConfigurations/EmbeddingAiModelConfig.cs
+++ b/CVBot.Infrastructure/AiConfigurations/EmbeddingAiModelConfig.cs
@@ -2,7 +2,7 @@ namespace CVBot.Infrastructure.AiConfigurations;
 
 public class EmbeddingAiModelConfig :AiModelConfig
 {
-    public required int MaxBatchElementsCount { get; init; }
-    public required int MaxBatchTokenCount { get; init; }
+    public required int MaxTokensPerLine { get; init; }
+    public required int MaxTokensPerParagraph { get; init; }
     public required int EmbeddingsDimension { get; init; }
 }

--- a/CVBot.Infrastructure/CVBot.Infrastructure.csproj
+++ b/CVBot.Infrastructure/CVBot.Infrastructure.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.63.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.63.0-preview" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.63.0-alpha" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/CVBot.Infrastructure/CvIngestion/CvIngestor.cs
+++ b/CVBot.Infrastructure/CvIngestion/CvIngestor.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics.CodeAnalysis;
+using CSharpFunctionalExtensions;
+using CVBot.Application.CvIngestion;
+using CVBot.Infrastructure.AiConfigurations;
+using CVBot.Infrastructure.CvStorage;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel.Text;
+
+namespace CVBot.Infrastructure.CvIngestion;
+
+public class CvIngestor(
+    ICvSemanticStoreWriter cvSemanticStoreWriter,
+    IOptions<EmbeddingAiModelConfig> embeddingAiModelConfig,
+    [FromKeyedServices(nameof(AiConfig.EmbeddingAiModel))]
+    IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
+    ILogger<CvIngestor> logger) : ICvIngestor
+{
+    private const string GenericFailureMessage = "Failed to ingest cv!";
+
+    [Experimental("SKEXP0050")]
+    public async Task<Result> IngestAsync(string cvText)
+    {
+        try
+        {
+            var lines = TextChunker.SplitPlainTextLines(cvText,
+                maxTokensPerLine: embeddingAiModelConfig.Value.MaxTokensPerLine);
+
+            var paragraphs = TextChunker.SplitPlainTextParagraphs(lines,
+                maxTokensPerParagraph: embeddingAiModelConfig.Value.MaxTokensPerParagraph);
+
+            var embeddedParagraphs = await embeddingGenerator.GenerateAsync(paragraphs,
+                new EmbeddingGenerationOptions() { Dimensions = embeddingAiModelConfig.Value.EmbeddingsDimension });
+
+            var semanticParagraphs = paragraphs.Zip(embeddedParagraphs).Select(zippedParagraph =>
+                new SemanticCvParagraph(Content: zippedParagraph.First, Embedding: zippedParagraph.Second));
+
+            await cvSemanticStoreWriter.SetCvContentAsync(semanticParagraphs);
+
+            return Result.Success();
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, GenericFailureMessage);
+            return Result.Failure(GenericFailureMessage);
+        }
+    }
+}

--- a/CVBot.Infrastructure/CvStorage/CvSemanticStoreRepository.cs
+++ b/CVBot.Infrastructure/CvStorage/CvSemanticStoreRepository.cs
@@ -1,0 +1,36 @@
+using CVBot.Infrastructure.AiConfigurations;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.VectorData;
+using Microsoft.SemanticKernel.Connectors.InMemory;
+
+namespace CVBot.Infrastructure.CvStorage;
+
+public class CvSemanticStoreRepository(
+    InMemoryVectorStore vectorStore,
+    IOptions<EmbeddingAiModelConfig> embeddingModelConfig) : ICvSemanticStoreWriter
+{
+    private const string CvCollectionName = "CvParagraphs";
+
+    public async Task SetCvContentAsync(IEnumerable<SemanticCvParagraph> semanticCvParagraphs)
+    {
+        var collection = await CreateOrResetCvCollectionAsync();
+        await collection.UpsertAsync(semanticCvParagraphs);
+    }
+
+    private async Task<InMemoryCollection<ulong, SemanticCvParagraph>> CreateOrResetCvCollectionAsync()
+    {
+        var collection = vectorStore.GetCollection<ulong, SemanticCvParagraph>(CvCollectionName,
+            new VectorStoreCollectionDefinition()
+            {
+                Properties =
+                [
+                    new VectorStoreVectorProperty(nameof(SemanticCvParagraph.Embedding),
+                        embeddingModelConfig.Value.EmbeddingsDimension)
+                ]
+            });
+
+        await collection.EnsureCollectionDeletedAsync();
+        await collection.EnsureCollectionExistsAsync();
+        return collection;
+    }
+}

--- a/CVBot.Infrastructure/CvStorage/ICvSemanticStoreWriter.cs
+++ b/CVBot.Infrastructure/CvStorage/ICvSemanticStoreWriter.cs
@@ -1,0 +1,6 @@
+namespace CVBot.Infrastructure.CvStorage;
+
+public interface ICvSemanticStoreWriter
+{
+    Task SetCvContentAsync(IEnumerable<SemanticCvParagraph> semanticParagraphs);
+}

--- a/CVBot.Infrastructure/CvStorage/SemanticCvParagraph.cs
+++ b/CVBot.Infrastructure/CvStorage/SemanticCvParagraph.cs
@@ -1,0 +1,6 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.VectorData;
+
+namespace CVBot.Infrastructure.CvStorage;
+
+public record SemanticCvParagraph(string Content, Embedding<float> Embedding);

--- a/CVBot.WebApi/Program.cs
+++ b/CVBot.WebApi/Program.cs
@@ -3,6 +3,8 @@ using CVBot.WebApi;
 var builder = WebApplication.CreateBuilder(args);
 
 var startup = new StartupHelper(builder.Configuration);
+startup.RegisterConfigs(builder.Services);
+
 #pragma warning disable SKEXP0010
 startup.ConfigureServices(builder.Services);
 #pragma warning restore SKEXP0010

--- a/CVBot.WebApi/StartupHelper.cs
+++ b/CVBot.WebApi/StartupHelper.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using CVBot.Infrastructure;
+using CVBot.Infrastructure.AiConfigurations;
 
 namespace CVBot.WebApi;
 
@@ -30,5 +31,12 @@ public class StartupHelper(IConfiguration configuration)
         app.UseRouting();
         app.UseAuthorization();
         app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+    }
+
+    public void RegisterConfigs(IServiceCollection services)
+    {
+        services.Configure<AiConfig>(configuration.GetRequiredSection(nameof(AiConfig)));
+        services.Configure<EmbeddingAiModelConfig>(
+            configuration.GetRequiredSection($"{nameof(AiConfig)}:{nameof(AiConfig.EmbeddingAiModel)}"));
     }
 }

--- a/CVBot.WebApi/appsettings.json
+++ b/CVBot.WebApi/appsettings.json
@@ -21,8 +21,8 @@
       "ApiKey": "dummy-api-key",
       "Endpoint": "http://localhost:11434",
       "DeploymentName": null,
-      "MaxBatchElementsCount": 100,
-      "MaxBatchTokenCount": 512,
+      "MaxTokensPerLine": 100,
+      "MaxTokensPerParagraph": 512,
       "EmbeddingsDimension": 768
     }
   }


### PR DESCRIPTION
In this pr:
  - Refactored an interface
  - Added CvIngestor to chunk and embed CV text using Semantic Kernel TextChunker
  - Implemented CvSemanticStoreRepository with InMemory vector store for embeddings
  - Created SemanticCvParagraph record to store content with embeddings
  - Added ICvSemanticStoreWriter interface for storage abstraction
  - Updated embedding config to use MaxTokensPerLine/Paragraph instead of batch limits
  - Configured DI for AiConfig and EmbeddingAiModelConfig in StartupHelper
  - Updated appsettings.json with new token limit properties
  - Added Microsoft.SemanticKernel.Connectors.InMemory package for vector storage